### PR TITLE
Add color wheel to output

### DIFF
--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -52,7 +52,7 @@ using namespace std;
 
 struct Vehicle
 {
-    Vehicle(const int width, const glm::vec2 &pos, const glm::vec2 &vel) : width(width), pos(pos), vel(vel) {}
+    Vehicle(const int width, const glm::vec2& pos, const glm::vec2& vel) : width(width), pos(pos), vel(vel) {}
 
     void move(float dt) { pos += vel * dt; }
 
@@ -65,7 +65,7 @@ struct Simulator
 {
     Simulator(int num_measurements) : num_measurements(num_measurements) {}
 
-    void addVehicle(const Vehicle &vehicle) { vehicles.push_back(vehicle); }
+    void addVehicle(const Vehicle& vehicle) { vehicles.push_back(vehicle); }
 
     std::vector<std::vector<float>> update(int steps, float dt)
     {
@@ -75,7 +75,7 @@ struct Simulator
         {
             std::vector<float> measurement(num_measurements, INFINITY);
 
-            for (auto &vehicle : vehicles)
+            for (auto& vehicle : vehicles)
             {
                 vehicle.move(dt);
 
@@ -101,7 +101,7 @@ float pignistic_transformation(float free_mass, float occ_mass)
     return occ_mass + 0.5f * (1.0f - occ_mass - free_mass);
 }
 
-cv::Mat compute_measurement_grid_image(const dogm::DOGM &grid_map)
+cv::Mat compute_measurement_grid_image(const dogm::DOGM& grid_map)
 {
     cv::Mat grid_img(grid_map.getGridSize(), grid_map.getGridSize(), CV_8UC3);
     for (int y = 0; y < grid_map.getGridSize(); y++)
@@ -110,7 +110,7 @@ cv::Mat compute_measurement_grid_image(const dogm::DOGM &grid_map)
         {
             int index = y * grid_map.getGridSize() + x;
 
-            const dogm::MeasurementCell &cell = grid_map.meas_cell_array[index];
+            const dogm::MeasurementCell& cell = grid_map.meas_cell_array[index];
             float occ = pignistic_transformation(cell.free_mass, cell.occ_mass);
             uchar temp = static_cast<uchar>(floor(occ * 255));
             grid_img.at<cv::Vec3b>(y, x) = cv::Vec3b(255 - temp, 255 - temp, 255 - temp);
@@ -120,7 +120,7 @@ cv::Mat compute_measurement_grid_image(const dogm::DOGM &grid_map)
     return grid_img;
 }
 
-cv::Mat compute_raw_measurement_grid_image(const dogm::DOGM &grid_map)
+cv::Mat compute_raw_measurement_grid_image(const dogm::DOGM& grid_map)
 {
     cv::Mat grid_img(grid_map.getGridSize(), grid_map.getGridSize(), CV_8UC3);
     for (int y = 0; y < grid_map.getGridSize(); y++)
@@ -128,7 +128,7 @@ cv::Mat compute_raw_measurement_grid_image(const dogm::DOGM &grid_map)
         for (int x = 0; x < grid_map.getGridSize(); x++)
         {
             int index = y * grid_map.getGridSize() + x;
-            const dogm::MeasurementCell &cell = grid_map.meas_cell_array[index];
+            const dogm::MeasurementCell& cell = grid_map.meas_cell_array[index];
             int red = static_cast<int>(cell.occ_mass * 255.0f);
             int green = static_cast<int>(cell.free_mass * 255.0f);
             int blue = 255 - red - green;
@@ -140,7 +140,7 @@ cv::Mat compute_raw_measurement_grid_image(const dogm::DOGM &grid_map)
     return grid_img;
 }
 
-cv::Mat compute_raw_polar_measurement_grid_image(const dogm::DOGM &grid_map)
+cv::Mat compute_raw_polar_measurement_grid_image(const dogm::DOGM& grid_map)
 {
     cv::Mat grid_img(grid_map.getGridSize(), 100, CV_8UC3);
     for (int y = 0; y < grid_map.getGridSize(); y++)
@@ -148,7 +148,7 @@ cv::Mat compute_raw_polar_measurement_grid_image(const dogm::DOGM &grid_map)
         for (int x = 0; x < 100; x++)
         {
             int index = y * 100 + x;
-            const dogm::MeasurementCell &cell = grid_map.polar_meas_cell_array[index];
+            const dogm::MeasurementCell& cell = grid_map.polar_meas_cell_array[index];
             int red = static_cast<int>(cell.occ_mass * 255.0f);
             int green = static_cast<int>(cell.free_mass * 255.0f);
             int blue = 255 - red - green;
@@ -180,7 +180,7 @@ cv::Mat createCircularColorGradient(const size_t hue_offset)
     return hue_image;
 }
 
-cv::Mat createCircleMask(const cv::Size2d &size)
+cv::Mat createCircleMask(const cv::Size2d& size)
 {
     cv::Mat mask{size, CV_8UC3, cv::Scalar(0, 0, 0)};
     const cv::Point image_center{mask.cols / 2, mask.rows / 2};
@@ -201,13 +201,13 @@ cv::Mat createColorWheel(const size_t hue_offset = 0)
     return color_wheel;
 }
 
-void resizeRelativeToShorterEdge(const cv::Mat &original_image, const float relative_size, cv::Mat &destination_image)
+void resizeRelativeToShorterEdge(const cv::Mat& original_image, const float relative_size, cv::Mat& destination_image)
 {
     const float target_edge_length = std::min(original_image.cols, original_image.rows) * relative_size;
     cv::resize(destination_image, destination_image, cv::Size(target_edge_length, target_edge_length));
 }
 
-cv::Mat createFullSaturationFullValueAlphaMaskOf(const cv::Mat &img)
+cv::Mat createFullSaturationFullValueAlphaMaskOf(const cv::Mat& img)
 {
     cv::Mat mask{};
     cv::Mat img_hsv{};
@@ -217,7 +217,7 @@ cv::Mat createFullSaturationFullValueAlphaMaskOf(const cv::Mat &img)
     return mask;
 }
 
-void blendIntoBottomRightCorner(cv::Mat &img_to_blend_in, cv::Mat &img)
+void blendIntoBottomRightCorner(cv::Mat& img_to_blend_in, cv::Mat& img)
 {
     const cv::Rect roi{img.cols - img_to_blend_in.cols, img.rows - img_to_blend_in.rows, img_to_blend_in.cols,
                        img_to_blend_in.rows};
@@ -227,14 +227,14 @@ void blendIntoBottomRightCorner(cv::Mat &img_to_blend_in, cv::Mat &img)
     cv::addWeighted(img_roi, 1.0F, img_to_blend_in, 1.0F, 0.0, img_roi);
 }
 
-void addColorWheelToBottomRightCorner(cv::Mat &img, const float relative_size = 0.2, const size_t hue_offset = 0)
+void addColorWheelToBottomRightCorner(cv::Mat& img, const float relative_size = 0.2, const size_t hue_offset = 0)
 {
     cv::Mat color_wheel = createColorWheel(hue_offset);
     resizeRelativeToShorterEdge(img, relative_size, color_wheel);
     blendIntoBottomRightCorner(color_wheel, img);
 }
 
-cv::Mat compute_dogm_image(const dogm::DOGM &grid_map, float occ_tresh = 0.7f, float m_tresh = 4.0f)
+cv::Mat compute_dogm_image(const dogm::DOGM& grid_map, float occ_tresh = 0.7f, float m_tresh = 4.0f)
 {
     cv::Mat grid_img(grid_map.getGridSize(), grid_map.getGridSize(), CV_8UC3);
     for (int y = 0; y < grid_map.getGridSize(); y++)
@@ -243,7 +243,7 @@ cv::Mat compute_dogm_image(const dogm::DOGM &grid_map, float occ_tresh = 0.7f, f
         {
             int index = y * grid_map.getGridSize() + x;
 
-            const dogm::GridCell &cell = grid_map.grid_cell_array[index];
+            const dogm::GridCell& cell = grid_map.grid_cell_array[index];
             float occ = pignistic_transformation(cell.free_mass, cell.occ_mass);
             uchar temp = static_cast<uchar>(floor(occ * 255));
 
@@ -287,12 +287,12 @@ cv::Mat compute_dogm_image(const dogm::DOGM &grid_map, float occ_tresh = 0.7f, f
     return grid_img;
 }
 
-cv::Mat compute_particles_image(const dogm::DOGM &grid_map)
+cv::Mat compute_particles_image(const dogm::DOGM& grid_map)
 {
     cv::Mat particles_img(grid_map.getGridSize(), grid_map.getGridSize(), CV_8UC3, cv::Scalar(0, 0, 0));
     for (int i = 0; i < grid_map.particle_count; i++)
     {
-        const dogm::Particle &part = grid_map.particle_array[i];
+        const dogm::Particle& part = grid_map.particle_array[i];
         float x = part.state[0];
         float y = part.state[1];
 
@@ -305,7 +305,7 @@ cv::Mat compute_particles_image(const dogm::DOGM &grid_map)
     return particles_img;
 }
 
-std::vector<float2> load_measurement_from_image(const std::string &file_name)
+std::vector<float2> load_measurement_from_image(const std::string& file_name)
 {
     cv::Mat grid_img = cv::imread(file_name);
 
@@ -330,7 +330,7 @@ std::vector<float2> load_measurement_from_image(const std::string &file_name)
     return meas_grid;
 }
 
-int main(int argc, const char **argv)
+int main(int argc, const char** argv)
 {
     std::vector<std::vector<float2>> mg_meas;
 

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -259,8 +259,7 @@ cv::Mat compute_dogm_image(const dogm::DOGM& grid_map, float occ_tresh = 0.7f, f
 
                 // printf("Angle: %f\n", angle);
 
-                // OpenCV hue range is [0, 179], see
-                // https://docs.opencv.org/3.2.0/df/d9d/tutorial_py_colorspaces.html
+                // OpenCV hue range is [0, 179], see https://docs.opencv.org/3.2.0/df/d9d/tutorial_py_colorspaces.html
                 const auto hue_opencv = static_cast<uint8_t>(angle * 0.5F);
                 cv::Mat hsv{1, 1, CV_8UC3, cv::Scalar(hue_opencv, 255, 255)};
                 cv::Mat rgb{1, 1, CV_8UC3};
@@ -360,66 +359,65 @@ int main(int argc, const char** argv)
 		// Update measurement grid
 		grid_map.updateMeasurementGridFromArray(mg_meas[i]);
 #else
-    dogm::GridParams params;
-    params.size = 50.0f;
-    params.resolution = 0.2f;
-    params.particle_count = 3 * static_cast<int>(10e5);
-    params.new_born_particle_count = 3 * static_cast<int>(10e4);
-    params.persistence_prob = 0.99f;
-    params.process_noise_position = 0.02f;
-    params.process_noise_velocity = 0.8f;
-    params.birth_prob = 0.02f;
-    params.velocity_persistent = 30.0f;
-    params.velocity_birth = 30.0f;
+	dogm::GridParams params;
+	params.size = 50.0f;
+	params.resolution = 0.2f;
+	params.particle_count = 3 * static_cast<int>(10e5);
+	params.new_born_particle_count = 3 * static_cast<int>(10e4);
+	params.persistence_prob = 0.99f;
+	params.process_noise_position = 0.02f;
+	params.process_noise_velocity = 0.8f;
+	params.birth_prob = 0.02f;
+	params.velocity_persistent = 30.0f;
+	params.velocity_birth = 30.0f;
 
-    dogm::LaserSensorParams laser_params;
-    laser_params.fov = 120.0f;
-    laser_params.max_range = 50.0f;
+	dogm::LaserSensorParams laser_params;
+	laser_params.fov = 120.0f;
+	laser_params.max_range = 50.0f;
 
-    dogm::DOGM grid_map(params, laser_params);
+	dogm::DOGM grid_map(params, laser_params);
 
-    Simulator simulator(100);
-    simulator.addVehicle(Vehicle(6, glm::vec2(20, 10), glm::vec2(0, 0)));
-    //	simulator.addVehicle(Vehicle(5, glm::vec2(46, 20), glm::vec2(0, 20)));
-    //	simulator.addVehicle(Vehicle(4, glm::vec2(80, 30), glm::vec2(0, -10)));
+	Simulator simulator(100);
+	simulator.addVehicle(Vehicle(6, glm::vec2(20, 10), glm::vec2(0, 0)));
+//	simulator.addVehicle(Vehicle(5, glm::vec2(46, 20), glm::vec2(0, 20)));
+//	simulator.addVehicle(Vehicle(4, glm::vec2(80, 30), glm::vec2(0, -10)));
 
-    simulator.addVehicle(Vehicle(6, glm::vec2(40, 30), glm::vec2(20, 5)));
-    simulator.addVehicle(Vehicle(5, glm::vec2(80, 24), glm::vec2(-15, -5)));
+	simulator.addVehicle(Vehicle(6, glm::vec2(40, 30), glm::vec2(20, 5)));
+	simulator.addVehicle(Vehicle(5, glm::vec2(80, 24), glm::vec2(-15, -5)));
 
-    float delta_time = 0.1f;
-    std::vector<std::vector<float>> sim_measurements = simulator.update(10, delta_time);
+	float delta_time = 0.1f;
+	std::vector<std::vector<float>> sim_measurements = simulator.update(10, delta_time);
 
-    for (int i = 0; i < sim_measurements.size(); i++)
-    {
-        grid_map.updateMeasurementGrid(sim_measurements[i].data(), sim_measurements[i].size());
+	for (int i = 0; i < sim_measurements.size(); i++)
+	{
+		grid_map.updateMeasurementGrid(sim_measurements[i].data(), sim_measurements[i].size());
 #endif
-    auto begin = chrono::high_resolution_clock::now();
+		auto begin = chrono::high_resolution_clock::now();
 
-    // Run Particle filter
-    grid_map.updateParticleFilter(delta_time);
+		// Run Particle filter
+		grid_map.updateParticleFilter(delta_time);
 
-    auto end = chrono::high_resolution_clock::now();
-    auto dur = end - begin;
-    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
-    std::cout << "### Iteration took: " << ms << " ms"
-              << " ###" << std::endl;
-    std::cout << "######  Saving result  #######" << std::endl;
-    std::cout << "##############################" << std::endl;
+		auto end = chrono::high_resolution_clock::now();
+		auto dur = end - begin;
+		auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+		std::cout << "### Iteration took: " << ms << " ms" << " ###" << std::endl;
+		std::cout << "######  Saving result  #######" << std::endl;
+		std::cout << "##############################" << std::endl;
 
-    cv::Mat meas_grid_img = compute_measurement_grid_image(grid_map);
-    cv::imwrite(cv::format("meas_grid_iter-%d.png", i + 1), meas_grid_img);
+		cv::Mat meas_grid_img = compute_measurement_grid_image(grid_map);
+		cv::imwrite(cv::format("meas_grid_iter-%d.png", i + 1), meas_grid_img);
 
-    cv::Mat raw_meas_grid_img = compute_raw_measurement_grid_image(grid_map);
-    cv::imwrite(cv::format("raw_grid_iter-%d.png", i + 1), raw_meas_grid_img);
+		cv::Mat raw_meas_grid_img = compute_raw_measurement_grid_image(grid_map);
+		cv::imwrite(cv::format("raw_grid_iter-%d.png", i + 1), raw_meas_grid_img);
 
-    cv::Mat grid_img = compute_dogm_image(grid_map, 0.7f, 4.0f);
-    cv::imwrite(cv::format("dogm_iter-%d.png", i + 1), grid_img);
+		cv::Mat grid_img = compute_dogm_image(grid_map, 0.7f, 4.0f);
+		cv::imwrite(cv::format("dogm_iter-%d.png", i + 1), grid_img);
 
-    cv::Mat particle_img = compute_particles_image(grid_map);
-    cv::imwrite(cv::format("particles_iter-%d.png", i + 1), particle_img);
-}
+		cv::Mat particle_img = compute_particles_image(grid_map);
+		cv::imwrite(cv::format("particles_iter-%d.png", i + 1), particle_img);
+	}
 
-#if 0
+#if	1
 	cv::Mat particle_img = compute_particles_image(grid_map);
 	cv::Mat grid_img = compute_dogm_image(grid_map, 0.7f, 4.0f);
 

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -211,7 +211,7 @@ cv::Mat createFullSaturationFullValueAlphaMaskOf(const cv::Mat& img)
     return mask;
 }
 
-void blendIntoBottomRightCorner(cv::Mat& img_to_blend_in, cv::Mat& img)
+void blendIntoBottomRightCorner(const cv::Mat& img_to_blend_in, cv::Mat& img)
 {
     const cv::Rect roi{img.cols - img_to_blend_in.cols, img.rows - img_to_blend_in.rows, img_to_blend_in.cols,
                        img_to_blend_in.rows};

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -275,7 +275,7 @@ cv::Mat compute_dogm_image(const dogm::DOGM& grid_map, float occ_tresh = 0.7f, f
         }
     }
 
-    addColorWheelToBottomRightCorner(grid_img, 0.15, 0);
+    addColorWheelToBottomRightCorner(grid_img);
 
     return grid_img;
 }

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -254,14 +254,13 @@ std::vector<float2> load_measurement_from_image(const std::string &file_name)
     return meas_grid;
 }
 
-void createColorWheelImageAndMask(cv::Mat &destination_image, cv::Mat &destination_mask, const size_t hue_offset)
+cv::Mat createCircularColorGradient(const size_t hue_offset)
 {
     // Set linear gradient (180 levels). Needed because the OpenCV hue range is [0, 179], see
     // https://docs.opencv.org/3.2.0/df/d9d/tutorial_py_colorspaces.html
     const size_t hue_steps = 180;
     cv::Mat hue_image(hue_steps, hue_steps, CV_8UC3, cv::Scalar(0));
-    cv::Mat mask(hue_image.size(), CV_8UC3, cv::Scalar(0, 0, 0));
-
+    const cv::Point image_center{hue_image.cols / 2, hue_image.rows / 2};
     cv::Mat hsv{1, 1, CV_8UC3, cv::Scalar(0, 255, 255)};
     cv::Mat rgb{1, 1, CV_8UC3};
     for (int hue = 0; hue < hue_image.rows; hue++)
@@ -270,46 +269,63 @@ void createColorWheelImageAndMask(cv::Mat &destination_image, cv::Mat &destinati
         cv::cvtColor(hsv, rgb, cv::COLOR_HSV2RGB);
         hue_image.row(hue).setTo(rgb.at<cv::Vec3b>(0, 0));
     }
-
-    cv::linearPolar(hue_image, hue_image, cv::Point(hue_image.cols / 2, hue_image.rows / 2), 255,
+    cv::linearPolar(hue_image, hue_image, image_center, 255,
                     cv::INTER_CUBIC | cv::WARP_FILL_OUTLIERS | cv::WARP_INVERSE_MAP);
-
-    cv::circle(mask, cv::Point(mask.cols / 2, mask.rows / 2), hue_image.rows / 2, cv::Scalar(1, 1, 1), -1);
-    cv::circle(mask, cv::Point(mask.cols / 2, mask.rows / 2), hue_image.rows / 4, cv::Scalar(0, 0, 0), -1);
-    hue_image.copyTo(destination_image, mask);
-    mask.copyTo(destination_mask);
+    return hue_image;
 }
 
-void resizeImagesRelativeToShorterEdge(const cv::Mat &original_img, const float relative_size,
-                                       std::vector<cv::Mat> imgs)
+cv::Mat createCircleMask(const cv::Size2d &size)
 {
-    const float edge_length{std::min(original_img.cols, original_img.rows) * relative_size};
-    for (auto &img : imgs)
-    {
-        cv::resize(img, img, cv::Size(edge_length, edge_length));
-    }
+    cv::Mat mask(size, CV_8UC3, cv::Scalar(0, 0, 0));
+    const cv::Point image_center{mask.cols / 2, mask.rows / 2};
+    const float outer_radius = mask.rows / 2;
+    const float inner_radius = mask.rows / 4;
+    cv::circle(mask, image_center, outer_radius, cv::Scalar(1, 1, 1), -1);
+    cv::circle(mask, image_center, inner_radius, cv::Scalar(0, 0, 0), -1);
+    return mask;
 }
 
-void blendIntoImage(cv::Mat &img, cv::Mat &img_to_blend_in, const cv::Mat &alpha_mask_of_img_to_blend_in)
+cv::Mat createColorWheel(const size_t hue_offset = 0)
 {
-    cv::Rect roi = cv::Rect(img.cols - img_to_blend_in.cols, img.rows - img_to_blend_in.rows, img_to_blend_in.cols,
-                            img_to_blend_in.rows);
+    cv::Mat circular_color_gradient = createCircularColorGradient(hue_offset);
+    cv::Mat circle_mask = createCircleMask(circular_color_gradient.size());
+
+    cv::Mat color_wheel{};
+    circular_color_gradient.copyTo(color_wheel, circle_mask);
+    return color_wheel;
+}
+
+void resizeRelativeToShorterEdge(const cv::Mat &original_image, const float relative_size, cv::Mat &destination_image)
+{
+    const float target_edge_length{std::min(original_image.cols, original_image.rows) * relative_size};
+    cv::resize(destination_image, destination_image, cv::Size(target_edge_length, target_edge_length));
+}
+
+cv::Mat createFullSaturationFullValueAlphaMaskOf(const cv::Mat &img)
+{
+    cv::Mat mask{};
+    cv::Mat img_hsv{};
+    cv::cvtColor(img, img_hsv, cv::COLOR_RGB2HSV);
+    cv::inRange(img_hsv, cv::Scalar(0, 254, 254), cv::Scalar(180, 255, 255), mask);
+    cv::cvtColor(mask, mask, cv::COLOR_GRAY2RGB);
+    return mask;
+}
+
+void blendIntoBottomRightCorner(cv::Mat &img_to_blend_in, cv::Mat &img)
+{
+    const cv::Rect roi = cv::Rect(img.cols - img_to_blend_in.cols, img.rows - img_to_blend_in.rows,
+                                  img_to_blend_in.cols, img_to_blend_in.rows);
     cv::Mat img_roi = img(roi);
-    // cv::Mat my_mask{};
-    // cv::threshold(img_to_blend_in, my_mask, cv::Scalar())
-    cv::multiply(cv::Scalar::all(1.0) - alpha_mask_of_img_to_blend_in, img_roi, img_roi);
+    cv::Mat mask = createFullSaturationFullValueAlphaMaskOf(img_to_blend_in);
+    cv::multiply(cv::Scalar::all(1.0) - mask, img_roi, img_roi);
     cv::addWeighted(img_roi, 1.0F, img_to_blend_in, 1.0F, 0.0, img_roi);
 }
 
-void addColorWheelToLowerRight(cv::Mat &img, const float relative_size = 0.2, const size_t hue_offset = 0)
+void addColorWheelToBottomRightCorner(cv::Mat &img, const float relative_size = 0.2, const size_t hue_offset = 0)
 {
-    cv::Mat color_wheel_rgb{};
-    cv::Mat color_wheel_mask{};
-    createColorWheelImageAndMask(color_wheel_rgb, color_wheel_mask, hue_offset);
-
-    resizeImagesRelativeToShorterEdge(img, relative_size, {color_wheel_rgb, color_wheel_mask});
-
-    blendIntoImage(img, color_wheel_rgb, color_wheel_mask);
+    cv::Mat color_wheel = createColorWheel(hue_offset);
+    resizeRelativeToShorterEdge(img, relative_size, color_wheel);
+    blendIntoBottomRightCorner(color_wheel, img);
 }
 
 int main(int argc, const char **argv)
@@ -317,7 +333,7 @@ int main(int argc, const char **argv)
 
     const size_t edge_img = 800;
     cv::Mat img(edge_img, 1.5 * edge_img, CV_8UC3, cv::Scalar(100, 100, 100));
-    addColorWheelToLowerRight(img, 0.15, 0);
+    addColorWheelToBottomRightCorner(img, 0.15, 0);
     cv::imshow("Added images", img);
 
     cv::waitKey(0);

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -363,7 +363,7 @@ int main(int argc, const char** argv)
     dogm::GridParams params;
     params.size = 50.0f;
     params.resolution = 0.2f;
-    params.particle_count = 6 * static_cast<int>(10e4);
+    params.particle_count = 3 * static_cast<int>(10e5);
     params.new_born_particle_count = 3 * static_cast<int>(10e4);
     params.persistence_prob = 0.99f;
     params.process_noise_position = 0.02f;


### PR DESCRIPTION
Show a color wheel indicating actor direction in the grid images, as advertised in the README: 

![dogm_iter-7](https://user-images.githubusercontent.com/27212661/78576637-39fd8980-782d-11ea-96a1-15ecf20bb26e.png)

Features:
- Wheel can be rotated with an integer parameter (orientation is currently correct)
- Wheel size is relative to original image, given by a float parameter

Considerations:
- I just put all this into main.cpp. I think we can devise a better structure for the new functions and for other free functions in `main.cpp`. I'm thinking of a utils file. If you agree, I could create a PR with a suggestion for that.