### PR TITLE
Fix simulator output coordinate system

### DIFF
--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -106,7 +106,7 @@ int main(int argc, const char** argv)
 	auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
 	std::cout << "### DOGM initialization took: " << ms << " ms" << " ###" << std::endl << std::endl;
 
-	Simulator simulator(100);
+	Simulator simulator(100, laser_params.fov);
 	simulator.addVehicle(Vehicle(6, glm::vec2(20, 10), glm::vec2(0, 0)));
 //	simulator.addVehicle(Vehicle(5, glm::vec2(46, 20), glm::vec2(0, 20)));
 //	simulator.addVehicle(Vehicle(4, glm::vec2(80, 30), glm::vec2(0, -10)));

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -107,12 +107,12 @@ int main(int argc, const char** argv)
 	std::cout << "### DOGM initialization took: " << ms << " ms" << " ###" << std::endl << std::endl;
 
 	Simulator simulator(100, laser_params.fov);
-	simulator.addVehicle(Vehicle(6, glm::vec2(20, 10), glm::vec2(0, 0)));
+	simulator.addVehicle(Vehicle(3, glm::vec2(30, 20), glm::vec2(0, 0)));
 //	simulator.addVehicle(Vehicle(5, glm::vec2(46, 20), glm::vec2(0, 20)));
 //	simulator.addVehicle(Vehicle(4, glm::vec2(80, 30), glm::vec2(0, -10)));
 
-	simulator.addVehicle(Vehicle(6, glm::vec2(40, 30), glm::vec2(20, 5)));
-	simulator.addVehicle(Vehicle(5, glm::vec2(80, 24), glm::vec2(-15, -5)));
+	simulator.addVehicle(Vehicle(6, glm::vec2(40, 35), glm::vec2(20, 0)));
+	simulator.addVehicle(Vehicle(5, glm::vec2(60, 24), glm::vec2(0, -10)));
 
 	float delta_time = 0.1f;
 	std::vector<std::vector<float>> sim_measurements = simulator.update(10, delta_time);

--- a/dogm/demo/simulator.h
+++ b/dogm/demo/simulator.h
@@ -25,6 +25,8 @@ SOFTWARE.
 #ifndef SIMULATOR_H
 #define SIMULATOR_H
 
+#define _USE_MATH_DEFINES
+#include <cmath>
 #include <glm/glm.hpp>
 #include <vector>
 
@@ -41,7 +43,10 @@ struct Vehicle
 
 struct Simulator
 {
-    Simulator(int num_measurements) : num_measurements(num_measurements) {}
+    Simulator(int _num_horizontal_scan_points, const float _field_of_view)
+        : num_horizontal_scan_points(_num_horizontal_scan_points), field_of_view(_field_of_view)
+    {
+    }
 
     void addVehicle(const Vehicle& vehicle) { vehicles.push_back(vehicle); }
 
@@ -51,17 +56,12 @@ struct Simulator
 
         for (int i = 0; i < steps; i++)
         {
-            std::vector<float> measurement(num_measurements, INFINITY);
+            std::vector<float> measurement(num_horizontal_scan_points, INFINITY);
 
             for (auto& vehicle : vehicles)
             {
                 vehicle.move(dt);
-
-                for (int i = 0; i < vehicle.width; i++)
-                {
-                    int index = static_cast<int>(vehicle.pos.x) + i;
-                    measurement[index] = vehicle.pos.y;
-                }
+                addVehicleDetectionsToMeasurement(vehicle, measurement);
             }
 
             measurements.push_back(measurement);
@@ -70,7 +70,46 @@ struct Simulator
         return measurements;
     }
 
-    int num_measurements;
+    void addVehicleDetectionsToMeasurement(const Vehicle& vehicle, std::vector<float>& measurement)
+    {
+        const float sensor_position_x = 50;
+        const float factor_angle_to_grid = (num_horizontal_scan_points / M_PI) * (180.0f / field_of_view);
+        const float angle_offset = num_horizontal_scan_points * (regressAngleOffset(180.0f - field_of_view) / 180.0f);
+
+        const float supersampling = 20.0f;
+        const int num_sample_points = vehicle.width * static_cast<int>(supersampling);
+        for (int point_on_vehicle = 0; point_on_vehicle < num_sample_points; ++point_on_vehicle)
+        {
+            const float x = vehicle.pos.x + static_cast<float>(point_on_vehicle) / supersampling - sensor_position_x;
+            const float radius = sqrtf(powf(x, 2) + powf(vehicle.pos.y, 2));
+
+            const float angle = M_PI - atan2(vehicle.pos.y, x);
+            const float angle_normalized_to_grid = (angle * factor_angle_to_grid) - angle_offset;
+
+            int index = static_cast<int>(angle_normalized_to_grid);
+            if (0 <= index && index <= measurement.size())
+                measurement[index] = radius;
+        }
+    }
+
+    float regressAngleOffset(float angle_difference)
+    {
+        // TODO find a final solution for this. The current regression is only an approximation to the true,
+        // unkown function. Error is mostly <0.5 degrees, <0.05 for an fov of 120 degrees.
+        // Expected results (found manually):
+        // angle_difference==90: return 90
+        // angle_difference==60: return 45
+        // angle_difference==45: return 30
+        // angle_difference==30: return 20
+        // angle_difference==15: return 7.5
+        // angle_difference== 0: return 0
+        angle_difference /= 100.0f;
+        return 76.7253f * powf(angle_difference, 3.0f) - 31.1917f * powf(angle_difference, 2.0f) +
+               66.6564 * angle_difference - 0.3819;
+    }
+
+    int num_horizontal_scan_points;
+    float field_of_view;
     std::vector<Vehicle> vehicles;
 };
 

--- a/dogm/demo/simulator.h
+++ b/dogm/demo/simulator.h
@@ -72,9 +72,11 @@ struct Simulator
 
     void addVehicleDetectionsToMeasurement(const Vehicle& vehicle, std::vector<float>& measurement)
     {
-        const float sensor_position_x = 50;
-        const float factor_angle_to_grid = (num_horizontal_scan_points / M_PI) * (180.0f / field_of_view);
-        const float angle_offset = num_horizontal_scan_points * (regressAngleOffset(180.0f - field_of_view) / 180.0f);
+        const float max_field_of_view = 180.0f;
+        const float sensor_position_x = num_horizontal_scan_points / 2;
+        const float factor_angle_to_grid = (num_horizontal_scan_points / M_PI) * (max_field_of_view / field_of_view);
+        const float angle_offset =
+            num_horizontal_scan_points * (regressAngleOffset(max_field_of_view - field_of_view) / max_field_of_view);
 
         const float supersampling = 20.0f;
         const int num_sample_points = vehicle.width * static_cast<int>(supersampling);
@@ -84,9 +86,9 @@ struct Simulator
             const float radius = sqrtf(powf(x, 2) + powf(vehicle.pos.y, 2));
 
             const float angle = M_PI - atan2(vehicle.pos.y, x);
-            const float angle_normalized_to_grid = (angle * factor_angle_to_grid) - angle_offset;
+            const float angle_normalized_to_measurement_vector = (angle * factor_angle_to_grid) - angle_offset;
 
-            int index = static_cast<int>(angle_normalized_to_grid);
+            int index = static_cast<int>(angle_normalized_to_measurement_vector);
             if (0 <= index && index <= measurement.size())
                 measurement[index] = radius;
         }


### PR DESCRIPTION
Solving blocker of #23: fix output coordinate system of simulator to be polar, not cartesian. Output coordinate system adapts to the sensor's field of view (FoV).

I found that the angle offset to compensate the changing FoV follows a strange function which I could not derive. I used regression to approximate it. This is a suboptimal solution, but the error is negligible (<0.05 degrees) at the currently used FoV of 120 degrees. Added TODO in code.