### PR TITLE
Resolve _USE_MATH_DEFINES double definition warning

### DIFF
--- a/dogm/demo/CMakeLists.txt
+++ b/dogm/demo/CMakeLists.txt
@@ -4,7 +4,7 @@ if (NOT OpenCV_FOUND)
 	set(OpenCV_LIBS "" CACHE FILEPATH "" )
 endif()
 
-add_definitions(-D_USE_MATH_DEFINES)
+add_definitions(-D_USE_MATH_DEFINES)  # Required to make M_PI from cmath available in MSVC
 
 add_executable(demo
 	main.cpp

--- a/dogm/demo/image_creation.h
+++ b/dogm/demo/image_creation.h
@@ -30,7 +30,6 @@ SOFTWARE.
 
 #include "dbscan.h"
 
-#define _USE_MATH_DEFINES
 #include <glm/glm.hpp>
 #include <opencv2/opencv.hpp>
 

--- a/dogm/demo/simulator.h
+++ b/dogm/demo/simulator.h
@@ -25,7 +25,6 @@ SOFTWARE.
 #ifndef SIMULATOR_H
 #define SIMULATOR_H
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <glm/glm.hpp>
 #include <vector>


### PR DESCRIPTION
With [this commit](https://github.com/TheCodez/dynamic-occupancy-grid-map/pull/28/commits/0bbba76653df4edda98fa43e71e58a0af504924d) from #28, my compiler warns me of double definitions of `_USE_MATH_DEFINES`. Resolving with this PR. I presume that this doesn't break the Windows build, correct?