### PR TITLE
Add clang format to CI

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,16 @@
+name: Format
+
+on: [push, pull_request]
+
+jobs:
+  clang-format:
+    name: clang-format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.5
+      with:
+        source: './dogm/'
+        exclude: './dogm/cmake'
+        extensions: 'h,cpp'
+        clangFormatVersion: 9

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -23,29 +23,3 @@ jobs:
     - name: Build
       run: cmake --build build
       working-directory: dogm
-
-
-  clang-format:
-    name: clang-format
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.5
-      with:
-        source: './dogm/'
-        exclude: './dogm/cmake'
-        extensions: 'h,cpp'
-        clangFormatVersion: 9
-
-
-  clang-format-alt:
-    name: clang-format-alt
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: unibeautify/clang-format:latest
-      with:
-        source: './dogm/'
-        exclude: './dogm/cmake'
-        extensions: 'h,cpp'
-        clangFormatVersion: 9

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -23,3 +23,29 @@ jobs:
     - name: Build
       run: cmake --build build
       working-directory: dogm
+
+
+  clang-format:
+    name: clang-format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: DoozyX/clang-format-lint-action@v0.5
+      with:
+        source: './dogm/'
+        exclude: './dogm/cmake'
+        extensions: 'h,cpp'
+        clangFormatVersion: 9
+
+
+  clang-format-alt:
+    name: clang-format-alt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: unibeautify/clang-format:latest
+      with:
+        source: './dogm/'
+        exclude: './dogm/cmake'
+        extensions: 'h,cpp'
+        clangFormatVersion: 9

--- a/dogm/include/dogm/common.h
+++ b/dogm/include/dogm/common.h
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2019 Michael Kösel
+Copyright (c) 2019 Michael KÃ¶sel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dogm/include/dogm/opengl/framebuffer.h
+++ b/dogm/include/dogm/opengl/framebuffer.h
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2019 Michael Kösel
+Copyright (c) 2019 Michael KÃ¶sel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dogm/include/dogm/opengl/polygon.h
+++ b/dogm/include/dogm/opengl/polygon.h
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2019 Michael Kösel
+Copyright (c) 2019 Michael KÃ¶sel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dogm/include/dogm/opengl/renderer.h
+++ b/dogm/include/dogm/opengl/renderer.h
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2019 Michael Kösel
+Copyright (c) 2019 Michael KÃ¶sel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dogm/include/dogm/opengl/shader.h
+++ b/dogm/include/dogm/opengl/shader.h
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2019 Michael Kösel
+Copyright (c) 2019 Michael KÃ¶sel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dogm/include/dogm/opengl/texture.h
+++ b/dogm/include/dogm/opengl/texture.h
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-Copyright (c) 2019 Michael Kösel
+Copyright (c) 2019 Michael KÃ¶sel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Addressing #31: Check code format with clang-format. Currently does not check .cu files, as the clang-format docker container has issues with some parts of that code (cannot reproduce locally, everything works fine with .cu files on my machine). I successfully verified that this catches wrong formatting.

Clang-format reported that in some files, the 'ö' was encoded wrongly. My editors also had problems with that. Now fixed.