### PR TITLE
Concatenate output images

### DIFF
--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -81,20 +81,7 @@ int main(int argc, const char** argv)
             computeCellsWithVelocity(grid_map, minimum_occupancy_threshold, minimum_velocity_threshold);
         precision_evaluator.evaluateAndStoreStep(step, cells_with_velocity);
 
-        // cv::Mat meas_grid_img = compute_measurement_grid_image(grid_map);
-        // cv::imwrite(cv::format("meas_grid_iter-%d.png", i + 1), meas_grid_img);
-
-        cv::Mat raw_meas_grid_img = compute_raw_measurement_grid_image(grid_map);
-        cv::imwrite(cv::format("raw_grid_iter-%d.png", step + 1), raw_meas_grid_img);
-
-        cv::Mat dogm_img = compute_dogm_image(grid_map, cells_with_velocity);
-        cv::imwrite(cv::format("dogm_iter-%d.png", step + 1), dogm_img);
-
-        cv::Mat particle_img = compute_particles_image(grid_map);
-        cv::imwrite(cv::format("particles_iter-%d.png", step + 1), particle_img);
-
-        cv::imshow("dogm", dogm_img);
-        cv::waitKey(1);
+        computeAndSaveResultImages(grid_map, cells_with_velocity, step);
     }
 
     cycle_timer.printStatsMs();

--- a/dogm/demo/utils/image_creation.cpp
+++ b/dogm/demo/utils/image_creation.cpp
@@ -245,7 +245,7 @@ void computeAndSaveResultImages(const dogm::DOGM& grid_map,
 
     if (show_during_execution)
     {
-        cv::namedWindow("DOGM", CV_WINDOW_NORMAL);
+        cv::namedWindow("DOGM", cv::WINDOW_NORMAL);
         cv::resizeWindow("DOGM", image_to_show.cols * 2, image_to_show.rows * 2);
         cv::imshow("DOGM", image_to_show);
         cv::waitKey(1);

--- a/dogm/demo/utils/image_creation.cpp
+++ b/dogm/demo/utils/image_creation.cpp
@@ -170,9 +170,26 @@ cv::Mat compute_particles_image(const dogm::DOGM& grid_map)
         float x = grid_map.particle_array.state[i][0];
         float y = grid_map.particle_array.state[i][1];
 
+        // TODO normalize this to the maximum particle count found in a cell. Currently, does not depict if more than
+        // 3*256 particles accumulate in one cell
         if ((x >= 0 && x < grid_map.getGridSize()) && (y >= 0 && y < grid_map.getGridSize()))
         {
-            particles_img.at<cv::Vec3b>(static_cast<int>(y), static_cast<int>(x)) = cv::Vec3b(0, 0, 255);
+            auto& cell = particles_img.at<cv::Vec3b>(static_cast<int>(y), static_cast<int>(x));
+            if (cell[1] == 255 && cell[2] == 255)
+            {
+                cell += cv::Vec3b(1, 0, 0);
+            }
+            else
+            {
+                if (cell[2] == 255)
+                {
+                    cell += cv::Vec3b(0, 1, 0);
+                }
+                else
+                {
+                    cell += cv::Vec3b(0, 0, 1);
+                }
+            }
         }
     }
 

--- a/dogm/demo/utils/image_creation.cpp
+++ b/dogm/demo/utils/image_creation.cpp
@@ -178,3 +178,33 @@ cv::Mat compute_particles_image(const dogm::DOGM& grid_map)
 
     return particles_img;
 }
+
+void computeAndSaveResultImages(const dogm::DOGM& grid_map,
+                                const std::vector<Point<dogm::GridCell>>& cells_with_velocity, const int step,
+                                const bool concatenate_images, const bool show_during_execution)
+{
+    cv::Mat raw_meas_grid_img = compute_raw_measurement_grid_image(grid_map);
+    cv::Mat particle_img = compute_particles_image(grid_map);
+    cv::Mat dogm_img = compute_dogm_image(grid_map, cells_with_velocity);
+
+    cv::Mat image_to_show{};
+    if (concatenate_images)
+    {
+        cv::hconcat(dogm_img, particle_img, image_to_show);
+        cv::hconcat(image_to_show, raw_meas_grid_img, image_to_show);
+        cv::imwrite(cv::format("outputs_iter-%d.png", step + 1), image_to_show);
+    }
+    else
+    {
+        cv::imwrite(cv::format("raw_grid_iter-%d.png", step + 1), raw_meas_grid_img);
+        cv::imwrite(cv::format("particles_iter-%d.png", step + 1), particle_img);
+        cv::imwrite(cv::format("dogm_iter-%d.png", step + 1), dogm_img);
+        image_to_show = dogm_img;
+    }
+
+    if (show_during_execution)
+    {
+        cv::imshow("dogm", image_to_show);
+        cv::waitKey(1);
+    }
+}

--- a/dogm/demo/utils/image_creation.cpp
+++ b/dogm/demo/utils/image_creation.cpp
@@ -204,7 +204,9 @@ void computeAndSaveResultImages(const dogm::DOGM& grid_map,
 
     if (show_during_execution)
     {
-        cv::imshow("dogm", image_to_show);
+        cv::namedWindow("DOGM", CV_WINDOW_NORMAL);
+        cv::resizeWindow("DOGM", image_to_show.cols * 2, image_to_show.rows * 2);
+        cv::imshow("DOGM", image_to_show);
         cv::waitKey(1);
     }
 }

--- a/dogm/demo/utils/image_creation.cpp
+++ b/dogm/demo/utils/image_creation.cpp
@@ -14,7 +14,6 @@
 #include <algorithm>
 #include <cmath>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 static float pignistic_transformation(float free_mass, float occ_mass)

--- a/dogm/demo/utils/image_creation.cpp
+++ b/dogm/demo/utils/image_creation.cpp
@@ -179,6 +179,17 @@ cv::Mat compute_particles_image(const dogm::DOGM& grid_map)
     return particles_img;
 }
 
+static void add_text(const std::string& text, const float relative_horizontal_position, cv::Mat& img)
+{
+    int fontFace = cv::FONT_HERSHEY_DUPLEX;
+    double fontScale = 1;
+    int thickness = 1;
+    int baseline{0};
+    cv::Size textSize = cv::getTextSize(text, fontFace, fontScale, thickness, &baseline);
+    cv::Point textOrg((img.cols - textSize.width) * relative_horizontal_position, (img.rows + textSize.height) * 0.5f);
+    cv::putText(img, text, textOrg, fontFace, fontScale, cv::Scalar::all(255), thickness, 8);
+}
+
 void computeAndSaveResultImages(const dogm::DOGM& grid_map,
                                 const std::vector<Point<dogm::GridCell>>& cells_with_velocity, const int step,
                                 const bool concatenate_images, const bool show_during_execution)
@@ -192,13 +203,20 @@ void computeAndSaveResultImages(const dogm::DOGM& grid_map,
     {
         cv::hconcat(dogm_img, particle_img, image_to_show);
         cv::hconcat(image_to_show, raw_meas_grid_img, image_to_show);
-        cv::imwrite(cv::format("outputs_iter-%d.png", step + 1), image_to_show);
+
+        cv::Mat subtitles(image_to_show.rows * 0.2f, image_to_show.cols, image_to_show.type(), cv::Scalar::all(30));
+        add_text("Grid", 0.13f, subtitles);
+        add_text("Particles", 0.5f, subtitles);
+        add_text("Measurement", 0.96f, subtitles);
+        cv::vconcat(image_to_show, subtitles, image_to_show);
+
+        cv::imwrite(cv::format("outputs_step_%d.png", step + 1), image_to_show);
     }
     else
     {
-        cv::imwrite(cv::format("raw_grid_iter-%d.png", step + 1), raw_meas_grid_img);
-        cv::imwrite(cv::format("particles_iter-%d.png", step + 1), particle_img);
-        cv::imwrite(cv::format("dogm_iter-%d.png", step + 1), dogm_img);
+        cv::imwrite(cv::format("raw_grid_step_%d.png", step + 1), raw_meas_grid_img);
+        cv::imwrite(cv::format("particles_step_%d.png", step + 1), particle_img);
+        cv::imwrite(cv::format("dogm_step_%d.png", step + 1), dogm_img);
         image_to_show = dogm_img;
     }
 

--- a/dogm/demo/utils/include/image_creation.h
+++ b/dogm/demo/utils/include/image_creation.h
@@ -22,4 +22,7 @@ cv::Mat compute_raw_polar_measurement_grid_image(const dogm::DOGM& grid_map);
 cv::Mat compute_dogm_image(const dogm::DOGM& grid_map, const std::vector<Point<dogm::GridCell>>& cells_with_velocity);
 cv::Mat compute_particles_image(const dogm::DOGM& grid_map);
 
+void computeAndSaveResultImages(const dogm::DOGM& grid_map,
+                                const std::vector<Point<dogm::GridCell>>& cells_with_velocity, const int step,
+                                const bool concatenate_images = true, const bool show_during_execution = true);
 #endif  // IMAGE_CREATION_H


### PR DESCRIPTION
- Show live output during execution at 2x magnification
- Optionally show and save all outputs in one image, see below. Enables more direct visual comparison. Enabled per default, only needs a bool switch to go back to previous behavior.

![outputs_iter-6](https://user-images.githubusercontent.com/27212661/80285542-117af800-8726-11ea-8284-2fb0e4aac522.png)

I thought something like this would be helpful when I planned how to find out where the remaining inaccuracies are (#23). The first thing I see in the above image is that subjectively, the particles are spread very far around the vehicles. Intuitively, I would expect a much tighter fit of the particle clusters to the vehicles. Do you agree with this or is my expectation wrong?

A significantly lower persistence probability (~0.5) achieves a tighter fit of particle clusters to the ground truth vehicles. This of course is far away from Nuss' parameters. What do you think is the right way to go here?

P.S.: I noticed that when disabling the image creation/display/saving altogether, my DOGM cycle times are improved:

```
# Everything enabled, as on this branch
  Minimum: 71ms
  Median:  83ms
  Mean:    82.8571ms
  Maximum: 102ms
```

```
# On this branch, main.cpp:84 commented out
  Minimum: 66ms
  Median:  70ms
  Mean:    71.1429ms
  Maximum: 85ms
```

I don't know how to explain this :sweat_smile: Maybe something related to CUDA 'cools down' during image saving?