### PR TITLE
Fix coordinate transforms

### DIFF
--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -51,14 +51,14 @@ int main(int argc, const char** argv)
 
     Simulator simulator(sensor_horizontal_scan_points, laser_params.fov, grid_params.size);
 #if 1
-    simulator.addVehicle(Vehicle(3, glm::vec2(25, 25), glm::vec2(10, 0)));
-    simulator.addVehicle(Vehicle(4, glm::vec2(10, 30), glm::vec2(15, 0)));
-    simulator.addVehicle(Vehicle(4, glm::vec2(15, 30), glm::vec2(0, -8)));
-    simulator.addVehicle(Vehicle(2, glm::vec2(35, 15), glm::vec2(0, 0)));
+    simulator.addVehicle(Vehicle(3.5, glm::vec2(10, 30), glm::vec2(15, 0)));
+    simulator.addVehicle(Vehicle(3.0, glm::vec2(10, 20), glm::vec2(0, 5)));
+    simulator.addVehicle(Vehicle(4.0, glm::vec2(35, 35), glm::vec2(0, -10)));
+    simulator.addVehicle(Vehicle(1.8, glm::vec2(45, 15), glm::vec2(0, 0)));
 #else
-    simulator.addVehicle(Vehicle(4, glm::vec2(30, 30), glm::vec2(10, -8)));
-    simulator.addVehicle(Vehicle(6, glm::vec2(60, 30), glm::vec2(-8, 6)));
-    simulator.addVehicle(Vehicle(3, glm::vec2(68, 15), glm::vec2(-12, 0)));
+    simulator.addVehicle(Vehicle(4.0, glm::vec2(10, 25), glm::vec2(10, -8)));
+    simulator.addVehicle(Vehicle(6.0, glm::vec2(40, 30), glm::vec2(-8, 6)));
+    simulator.addVehicle(Vehicle(3.0, glm::vec2(48, 15), glm::vec2(-12, 0)));
 #endif
 
     SimulationData sim_data = simulator.update(num_simulation_steps, simulation_step_period);

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, const char** argv)
     const int sensor_horizontal_scan_points = 100;
 
     // Simulator parameters
-    const int simulation_steps = 14;
+    const int num_simulation_steps = 14;
     const float simulation_step_period = 0.1f;
 
     // Evaluator parameters
@@ -65,21 +65,17 @@ int main(int argc, const char** argv)
     PrecisionEvaluator precision_evaluator{sim_data, grid_params.resolution};
     Timer cycle_timer{"DOGM cycle"};
 
-    for (int step = 0; step < simulation_steps; ++step)
+    for (int step = 0; step < num_simulation_steps; ++step)
     {
         grid_map.updateMeasurementGrid(sim_data[step].measurements);
 
         cycle_timer.tic();
-        // Run Particle filter
         grid_map.updateParticleFilter(simulation_step_period);
-
         cycle_timer.toc(true);
-        std::cout << "######  Saving result  #######" << std::endl;
-        std::cout << "##############################" << std::endl << std::endl;
 
         const auto cells_with_velocity =
             computeCellsWithVelocity(grid_map, minimum_occupancy_threshold, minimum_velocity_threshold);
-        precision_evaluator.evaluateAndStoreStep(step, cells_with_velocity, true);
+        precision_evaluator.evaluateAndStoreStep(step, cells_with_velocity);
 
         computeAndSaveResultImages(grid_map, cells_with_velocity, step);
     }

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, const char** argv)
     dogm::LaserSensorParams laser_params;
     laser_params.fov = 120.0f;
     laser_params.max_range = 50.0f;
-    laser_params.resolution = 0.2f;
+    laser_params.resolution = grid_params.resolution;  // TODO make independent of grid_params.resolution
     const int sensor_horizontal_scan_points = 100;
 
     // Simulator parameters

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -33,9 +33,9 @@ int main(int argc, const char** argv)
     laser_params.max_range = 50.0f;
     laser_params.resolution = 0.2f;
     const int sensor_horizontal_scan_points =
-        50;  // velocity on grid is still dependent on this variable! Position
-             // also, slightly. Width should also be dependent
-             // Issue must be in further processing of msmt. Simulator works now as expected.
+        100;  // velocity on grid is still dependent on this variable! Position
+              // also, slightly. Width should also be dependent
+              // Issue must be in further processing of msmt. Simulator works now as expected.
 
     // Simulator parameters
     const int simulation_steps = 14;
@@ -55,7 +55,7 @@ int main(int argc, const char** argv)
     CoordinateSystemMapper mapper{grid_params.size, grid_params.resolution};
     Simulator simulator(sensor_horizontal_scan_points, laser_params.fov, mapper);
 #if 1
-    simulator.addVehicle(Vehicle(3, glm::vec2(20, 25), glm::vec2(10, 0)));
+    simulator.addVehicle(Vehicle(3, glm::vec2(25, 25), glm::vec2(0, 10)));
     // simulator.addVehicle(Vehicle(4, glm::vec2(30, 30), glm::vec2(15, 0)));
     // simulator.addVehicle(Vehicle(4, glm::vec2(60, 30), glm::vec2(0, -8)));
     // simulator.addVehicle(Vehicle(2, glm::vec2(68, 15), glm::vec2(0, 0)));

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -32,10 +32,7 @@ int main(int argc, const char** argv)
     laser_params.fov = 120.0f;
     laser_params.max_range = 50.0f;
     laser_params.resolution = 0.2f;
-    const int sensor_horizontal_scan_points =
-        100;  // velocity on grid is still dependent on this variable! Position
-              // also, slightly. Width should also be dependent
-              // Issue must be in further processing of msmt. Simulator works now as expected.
+    const int sensor_horizontal_scan_points = 100;
 
     // Simulator parameters
     const int simulation_steps = 14;
@@ -52,13 +49,12 @@ int main(int argc, const char** argv)
     dogm::DOGM grid_map(grid_params, laser_params);
     initialization_timer.toc(true);
 
-    CoordinateSystemMapper mapper{grid_params.size, grid_params.resolution};
-    Simulator simulator(sensor_horizontal_scan_points, laser_params.fov, mapper);
+    Simulator simulator(sensor_horizontal_scan_points, laser_params.fov, grid_params.size);
 #if 1
-    simulator.addVehicle(Vehicle(3, glm::vec2(25, 25), glm::vec2(0, 10)));
-    // simulator.addVehicle(Vehicle(4, glm::vec2(30, 30), glm::vec2(15, 0)));
-    // simulator.addVehicle(Vehicle(4, glm::vec2(60, 30), glm::vec2(0, -8)));
-    // simulator.addVehicle(Vehicle(2, glm::vec2(68, 15), glm::vec2(0, 0)));
+    simulator.addVehicle(Vehicle(3, glm::vec2(25, 25), glm::vec2(10, 0)));
+    // simulator.addVehicle(Vehicle(4, glm::vec2(10, 30), glm::vec2(15, 0)));
+    // simulator.addVehicle(Vehicle(4, glm::vec2(15, 30), glm::vec2(0, -8)));
+    // simulator.addVehicle(Vehicle(2, glm::vec2(35, 15), glm::vec2(0, 0)));
 #else
     simulator.addVehicle(Vehicle(4, glm::vec2(30, 30), glm::vec2(10, -8)));
     simulator.addVehicle(Vehicle(6, glm::vec2(60, 30), glm::vec2(-8, 6)));

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -52,17 +52,17 @@ int main(int argc, const char** argv)
     Simulator simulator(sensor_horizontal_scan_points, laser_params.fov, grid_params.size);
 #if 1
     simulator.addVehicle(Vehicle(3, glm::vec2(25, 25), glm::vec2(10, 0)));
-    // simulator.addVehicle(Vehicle(4, glm::vec2(10, 30), glm::vec2(15, 0)));
-    // simulator.addVehicle(Vehicle(4, glm::vec2(15, 30), glm::vec2(0, -8)));
-    // simulator.addVehicle(Vehicle(2, glm::vec2(35, 15), glm::vec2(0, 0)));
+    simulator.addVehicle(Vehicle(4, glm::vec2(10, 30), glm::vec2(15, 0)));
+    simulator.addVehicle(Vehicle(4, glm::vec2(15, 30), glm::vec2(0, -8)));
+    simulator.addVehicle(Vehicle(2, glm::vec2(35, 15), glm::vec2(0, 0)));
 #else
     simulator.addVehicle(Vehicle(4, glm::vec2(30, 30), glm::vec2(10, -8)));
     simulator.addVehicle(Vehicle(6, glm::vec2(60, 30), glm::vec2(-8, 6)));
     simulator.addVehicle(Vehicle(3, glm::vec2(68, 15), glm::vec2(-12, 0)));
 #endif
 
-    SimulationData sim_data = simulator.update(simulation_steps, simulation_step_period);
-    PrecisionEvaluator precision_evaluator{sim_data, grid_params.resolution};
+    SimulationData sim_data = simulator.update(num_simulation_steps, simulation_step_period);
+    PrecisionEvaluator precision_evaluator{sim_data, grid_params.resolution, grid_params.size};
     Timer cycle_timer{"DOGM cycle"};
 
     for (int step = 0; step < num_simulation_steps; ++step)

--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -32,7 +32,10 @@ int main(int argc, const char** argv)
     laser_params.fov = 120.0f;
     laser_params.max_range = 50.0f;
     laser_params.resolution = 0.2f;
-    const int sensor_horizontal_scan_points = 100;
+    const int sensor_horizontal_scan_points =
+        50;  // velocity on grid is still dependent on this variable! Position
+             // also, slightly. Width should also be dependent
+             // Issue must be in further processing of msmt. Simulator works now as expected.
 
     // Simulator parameters
     const int simulation_steps = 14;
@@ -49,12 +52,13 @@ int main(int argc, const char** argv)
     dogm::DOGM grid_map(grid_params, laser_params);
     initialization_timer.toc(true);
 
-    Simulator simulator(sensor_horizontal_scan_points, laser_params.fov);
+    CoordinateSystemMapper mapper{grid_params.size, grid_params.resolution};
+    Simulator simulator(sensor_horizontal_scan_points, laser_params.fov, mapper);
 #if 1
-    simulator.addVehicle(Vehicle(3, glm::vec2(30, 20), glm::vec2(0, 6)));
-    simulator.addVehicle(Vehicle(4, glm::vec2(30, 30), glm::vec2(15, 0)));
-    simulator.addVehicle(Vehicle(4, glm::vec2(60, 30), glm::vec2(0, -8)));
-    simulator.addVehicle(Vehicle(2, glm::vec2(68, 15), glm::vec2(0, 0)));
+    simulator.addVehicle(Vehicle(3, glm::vec2(20, 25), glm::vec2(10, 0)));
+    // simulator.addVehicle(Vehicle(4, glm::vec2(30, 30), glm::vec2(15, 0)));
+    // simulator.addVehicle(Vehicle(4, glm::vec2(60, 30), glm::vec2(0, -8)));
+    // simulator.addVehicle(Vehicle(2, glm::vec2(68, 15), glm::vec2(0, 0)));
 #else
     simulator.addVehicle(Vehicle(4, glm::vec2(30, 30), glm::vec2(10, -8)));
     simulator.addVehicle(Vehicle(6, glm::vec2(60, 30), glm::vec2(-8, 6)));
@@ -79,7 +83,7 @@ int main(int argc, const char** argv)
 
         const auto cells_with_velocity =
             computeCellsWithVelocity(grid_map, minimum_occupancy_threshold, minimum_velocity_threshold);
-        precision_evaluator.evaluateAndStoreStep(step, cells_with_velocity);
+        precision_evaluator.evaluateAndStoreStep(step, cells_with_velocity, true);
 
         computeAndSaveResultImages(grid_map, cells_with_velocity, step);
     }

--- a/dogm/demo/utils/image_creation.cpp
+++ b/dogm/demo/utils/image_creation.cpp
@@ -50,8 +50,10 @@ std::vector<Point<dogm::GridCell>> computeCellsWithVelocity(const dogm::DOGM& gr
                 velocity_normalized_by_variance.at<float>(0, 0) >= min_velocity_threshold)
             {
                 Point<dogm::GridCell> point;
-                point.x = x;
-                point.y = y;
+
+                // Storing the point as grid index to be consistent with cell.mean_x_vel and cell.mean_y_vel
+                point.x = static_cast<float>(x);
+                point.y = static_cast<float>(y);
                 point.data = cell;
                 point.cluster_id = UNCLASSIFIED;
 

--- a/dogm/demo/utils/include/precision_evaluator.h
+++ b/dogm/demo/utils/include/precision_evaluator.h
@@ -22,7 +22,7 @@ struct PointWithVelocity
 class PrecisionEvaluator
 {
 public:
-    PrecisionEvaluator(const SimulationData _sim_data, const float _resolution);
+    PrecisionEvaluator(const SimulationData sim_data, const float resolution, const float grid_size);
     void evaluateAndStoreStep(int simulation_step_index, const std::vector<Point<dogm::GridCell>>& cells_with_velocity,
                               bool print_current_precision = false);
     void printSummary();
@@ -33,6 +33,7 @@ private:
 
     SimulationData sim_data;
     float resolution;
+    float grid_size;
     PointWithVelocity cumulative_error;
     int number_of_detections;
     int number_of_unassigned_detections;

--- a/dogm/demo/utils/include/simulator.h
+++ b/dogm/demo/utils/include/simulator.h
@@ -42,13 +42,9 @@ using SimulationData = std::vector<SimulationStep>;
 class Simulator
 {
 public:
-    Simulator(int _num_horizontal_scan_points, const float _field_of_view, const float grid_size)
-        : num_horizontal_scan_points(_num_horizontal_scan_points), field_of_view(_field_of_view), grid_size{grid_size}
-    {
-    }
+    Simulator(int _num_horizontal_scan_points, const float _field_of_view, const float grid_size);
 
     void addVehicle(const Vehicle& vehicle) { vehicles.push_back(vehicle); }
-
     SimulationData update(int steps, float dt);
     void addVehicleDetectionsToMeasurement(const Vehicle& vehicle, std::vector<float>& measurement) const;
 
@@ -58,6 +54,10 @@ public:
 
 private:
     float grid_size;
+    int computeMeasurementVectorIndexFromAngle(const float angle) const;
+    float factor_angle_to_grid;
+    float angle_offset;
+    glm::vec2 sensor_position;
 };
 
 #endif  // SIMULATOR_H

--- a/dogm/demo/utils/include/simulator.h
+++ b/dogm/demo/utils/include/simulator.h
@@ -43,18 +43,17 @@ class Simulator
 {
 public:
     Simulator(int _num_horizontal_scan_points, const float _field_of_view, const float grid_size);
-
     void addVehicle(const Vehicle& vehicle) { vehicles.push_back(vehicle); }
     SimulationData update(int steps, float dt);
-    void addVehicleDetectionsToMeasurement(const Vehicle& vehicle, std::vector<float>& measurement) const;
-
-    int num_horizontal_scan_points;
-    float field_of_view;
-    std::vector<Vehicle> vehicles;
 
 private:
-    float grid_size;
+    void addVehicleDetectionsToMeasurement(const Vehicle& vehicle, std::vector<float>& measurement) const;
     int computeMeasurementVectorIndexFromAngle(const float angle) const;
+
+    float field_of_view;
+    int num_horizontal_scan_points;
+    std::vector<Vehicle> vehicles;
+    float grid_size;
     float factor_angle_to_grid;
     float angle_offset;
     glm::vec2 sensor_position;

--- a/dogm/demo/utils/include/simulator.h
+++ b/dogm/demo/utils/include/simulator.h
@@ -8,33 +8,27 @@
 #include <glm/glm.hpp>
 #include <vector>
 
-class CoordinateSystemMapper
-{
-public:
-    CoordinateSystemMapper(const float grid_size, const float grid_resolution)
-        : grid_size{grid_size}, grid_resolution{grid_resolution}
-    {
-    }
-
-    float mapAbsoluteGridPositionToRelativePosition(const float position_in_meters)
-    {
-        return position_in_meters / grid_size;
-    }
-
-private:
-    float grid_size;
-    float grid_resolution;
-};
-
 struct Vehicle
 {
-    Vehicle(const int width, const glm::vec2& pos, const glm::vec2& vel) : width(width), pos(pos), vel(vel) {}
+    // Construct a vehicle from the perspective of a sensor. Vehicles do not have bounding boxes, but are represented
+    // only by one facing side. This facing side has a width [m] and a 2D position [m]. Position is in the center of the
+    // facing side. 2D Velocity is given in [m/s].
+    Vehicle(const int width, const glm::vec2& position, const glm::vec2& velocity)
+        : width(width), pos(position), vel(velocity)
+    {
+    }
 
     void move(float dt) { pos += vel * dt; }
 
-    int width;
+    /// brief Gets points on facing side
+    /// param resolution [m] defines in which resolution points shall be sampled
+    std::vector<glm::vec2> getPointsOnFacingSide(const float resolution) const;
+
     glm::vec2 pos;
     glm::vec2 vel;
+
+private:
+    float width;
 };
 
 struct SimulationStep
@@ -45,10 +39,11 @@ struct SimulationStep
 
 using SimulationData = std::vector<SimulationStep>;
 
-struct Simulator
+class Simulator
 {
-    Simulator(int _num_horizontal_scan_points, const float _field_of_view, CoordinateSystemMapper& mapper)
-        : num_horizontal_scan_points(_num_horizontal_scan_points), field_of_view(_field_of_view), mapper{mapper}
+public:
+    Simulator(int _num_horizontal_scan_points, const float _field_of_view, const float grid_size)
+        : num_horizontal_scan_points(_num_horizontal_scan_points), field_of_view(_field_of_view), grid_size{grid_size}
     {
     }
 
@@ -60,7 +55,9 @@ struct Simulator
     int num_horizontal_scan_points;
     float field_of_view;
     std::vector<Vehicle> vehicles;
-    CoordinateSystemMapper& mapper;
+
+private:
+    float grid_size;
 };
 
 #endif  // SIMULATOR_H

--- a/dogm/demo/utils/include/simulator.h
+++ b/dogm/demo/utils/include/simulator.h
@@ -20,8 +20,7 @@ struct Vehicle
 
     void move(float dt) { pos += vel * dt; }
 
-    /// brief Gets points on facing side
-    /// param resolution [m] defines in which resolution points shall be sampled
+    // Gets points on facing side. Resolution [m] defines in which resolution points shall be sampled
     std::vector<glm::vec2> getPointsOnFacingSide(const float resolution) const;
 
     glm::vec2 pos;

--- a/dogm/demo/utils/include/simulator.h
+++ b/dogm/demo/utils/include/simulator.h
@@ -8,6 +8,24 @@
 #include <glm/glm.hpp>
 #include <vector>
 
+class CoordinateSystemMapper
+{
+public:
+    CoordinateSystemMapper(const float grid_size, const float grid_resolution)
+        : grid_size{grid_size}, grid_resolution{grid_resolution}
+    {
+    }
+
+    float mapAbsoluteGridPositionToRelativePosition(const float position_in_meters)
+    {
+        return position_in_meters / grid_size;
+    }
+
+private:
+    float grid_size;
+    float grid_resolution;
+};
+
 struct Vehicle
 {
     Vehicle(const int width, const glm::vec2& pos, const glm::vec2& vel) : width(width), pos(pos), vel(vel) {}
@@ -29,8 +47,8 @@ using SimulationData = std::vector<SimulationStep>;
 
 struct Simulator
 {
-    Simulator(int _num_horizontal_scan_points, const float _field_of_view)
-        : num_horizontal_scan_points(_num_horizontal_scan_points), field_of_view(_field_of_view)
+    Simulator(int _num_horizontal_scan_points, const float _field_of_view, CoordinateSystemMapper& mapper)
+        : num_horizontal_scan_points(_num_horizontal_scan_points), field_of_view(_field_of_view), mapper{mapper}
     {
     }
 
@@ -42,6 +60,7 @@ struct Simulator
     int num_horizontal_scan_points;
     float field_of_view;
     std::vector<Vehicle> vehicles;
+    CoordinateSystemMapper& mapper;
 };
 
 #endif  // SIMULATOR_H

--- a/dogm/demo/utils/precision_evaluator.cpp
+++ b/dogm/demo/utils/precision_evaluator.cpp
@@ -98,6 +98,7 @@ void PrecisionEvaluator::evaluateAndStoreStep(int simulation_step_index,
 
 PointWithVelocity PrecisionEvaluator::computeClusterMean(const Cluster<dogm::GridCell>& cluster)
 {
+    // TODO check if median is more precise than mean
     PointWithVelocity cluster_mean;
     for (auto& point : cluster)
     {

--- a/dogm/demo/utils/precision_evaluator.cpp
+++ b/dogm/demo/utils/precision_evaluator.cpp
@@ -32,8 +32,8 @@ static Clusters<dogm::GridCell> computeDbscanClusters(const std::vector<Point<do
     return dbscan.cluster(cells_with_velocity);
 }
 
-PrecisionEvaluator::PrecisionEvaluator(const SimulationData _sim_data, const float _resolution)
-    : sim_data{_sim_data}, resolution{_resolution}
+PrecisionEvaluator::PrecisionEvaluator(const SimulationData _sim_data, const float _resolution, const float _grid_size)
+    : sim_data{_sim_data}, resolution{_resolution}, grid_size{_grid_size}
 {
     number_of_detections = 0;
     number_of_unassigned_detections = 0;
@@ -110,12 +110,13 @@ PointWithVelocity PrecisionEvaluator::computeClusterMean(const Cluster<dogm::Gri
     cluster_mean.x = (cluster_mean.x / cluster.size()) * resolution;
     cluster_mean.y = (cluster_mean.y / cluster.size()) * resolution;
     cluster_mean.v_x = (cluster_mean.v_x / cluster.size()) * resolution;
-    cluster_mean.v_y = -(cluster_mean.v_y / cluster.size()) * resolution;
+    cluster_mean.v_y = (cluster_mean.v_y / cluster.size()) * resolution;
 
-    const float x_offset = 22.0f;                            // motivated by numerical experiments
-    const float y_offset = 2.0f * (25.0f - cluster_mean.y);  // motivated by numerical experiments
-    cluster_mean.x += x_offset;
-    cluster_mean.y += y_offset;
+    // y as grid index is pointing downwards from top left corner.
+    // y in world coordinates is pointing upwards from bottom left corner.
+    // Therefore, vectors (velocity) just needs to be inverted. Positions (mean) must be inverted and translated.
+    cluster_mean.v_y = -cluster_mean.v_y;
+    cluster_mean.y = grid_size - cluster_mean.y;
 
     return cluster_mean;
 }

--- a/dogm/demo/utils/simulator.cpp
+++ b/dogm/demo/utils/simulator.cpp
@@ -58,11 +58,14 @@ void Simulator::addVehicleDetectionsToMeasurement(const Vehicle& vehicle, std::v
 
     const float supersampling = 20.0f;
     const int num_sample_points = vehicle.width * static_cast<int>(supersampling);
-    for (int point_on_vehicle = 0; point_on_vehicle < num_sample_points; ++point_on_vehicle)
+    for (int point_on_vehicle = -num_sample_points / 2;
+         point_on_vehicle < num_sample_points / 2;  // centering around vehicle position
+         ++point_on_vehicle)
     {
-        const float x =
-            mapper.mapAbsoluteGridPositionToRelativePosition(vehicle.pos.x) * float(num_horizontal_scan_points) +
-            static_cast<float>(point_on_vehicle) / supersampling - sensor_position_x;
+        const float x = mapper.mapAbsoluteGridPositionToRelativePosition(
+                            vehicle.pos.x + static_cast<float>(point_on_vehicle) / supersampling) *
+                            float(num_horizontal_scan_points) -
+                        sensor_position_x;
         const float radius = sqrtf(powf(x, 2) + powf(vehicle.pos.y, 2));
 
         const float angle = M_PI - atan2(vehicle.pos.y, x);

--- a/dogm/demo/utils/simulator.cpp
+++ b/dogm/demo/utils/simulator.cpp
@@ -6,6 +6,7 @@
 
 #include <cmath>
 #include <glm/glm.hpp>
+#include <iostream>
 #include <vector>
 
 static float regressAngleOffset(float angle_difference)
@@ -59,7 +60,9 @@ void Simulator::addVehicleDetectionsToMeasurement(const Vehicle& vehicle, std::v
     const int num_sample_points = vehicle.width * static_cast<int>(supersampling);
     for (int point_on_vehicle = 0; point_on_vehicle < num_sample_points; ++point_on_vehicle)
     {
-        const float x = vehicle.pos.x + static_cast<float>(point_on_vehicle) / supersampling - sensor_position_x;
+        const float x =
+            mapper.mapAbsoluteGridPositionToRelativePosition(vehicle.pos.x) * float(num_horizontal_scan_points) +
+            static_cast<float>(point_on_vehicle) / supersampling - sensor_position_x;
         const float radius = sqrtf(powf(x, 2) + powf(vehicle.pos.y, 2));
 
         const float angle = M_PI - atan2(vehicle.pos.y, x);

--- a/dogm/demo/utils/simulator.cpp
+++ b/dogm/demo/utils/simulator.cpp
@@ -6,7 +6,6 @@
 
 #include <cmath>
 #include <glm/glm.hpp>
-#include <iostream>
 #include <vector>
 
 std::vector<glm::vec2> Vehicle::getPointsOnFacingSide(const float resolution) const

--- a/dogm/demo/utils/test/simulator_spec.cpp
+++ b/dogm/demo/utils/test/simulator_spec.cpp
@@ -15,7 +15,6 @@ TEST(Vehicle, Constructor)
 
     Vehicle unit{width, position, velocity};
 
-    EXPECT_EQ(width, unit.width);
     EXPECT_EQ(position, unit.pos);
     EXPECT_EQ(velocity, unit.vel);
 }

--- a/dogm/src/dogm.cu
+++ b/dogm/src/dogm.cu
@@ -413,7 +413,7 @@ void DOGM::resampling()
 
     float new_weight = joint_max / particle_count;
 
-    printf("joint_max: %f\n", joint_max);
+    // printf("joint_max: %f\n", joint_max);
 
     resamplingKernel<<<particles_grid, block_dim>>>(particle_array, particle_array_next, birth_particle_array,
                                                     idx_array_resampled, new_weight, particle_count);


### PR DESCRIPTION
Continuing #23: Replaced all unknown transforms from the simulation and evaluation chain except angle regression by well-understood transforms.
- Fix coordinate transforms in simulator and precision evaluator.
  -  In the measurement grid, vehicles are now at the coordinates defined in their constructor. Examples: Vehicle at position (10,20) will be at pixels (10/resolution, 20/resolution). A vehicle with position (grid_size, grid_size) will be at the top right of the grid.
  - Same for velocity: I verified that e.g. a vehicle with a speed of 10m/s covers 10/resolution pixels in one second.
  - Both simulator and evaluator now take grid size, grid resolution, number of scan points, and sensor FoV into account. They work for arbitrary values (within a sensible range :wink: ) in these four variables.
- Vehicle positions now denote their center. Makes precision evaluation simpler
- In code, I noted that laser.max_range must be grid_size, otherwise vehicle positions are incorrect. Same for resolutions.
- Removed visual clutter from demo output

I think this is a substantial improvement for simulation and evaluation. Now we understand them almost entirely.