### PR TITLE
Use ctest for unit tests in CI

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -24,5 +24,5 @@ jobs:
       run: cmake --build build
       working-directory: dogm
     - name: Test Utils
-      run: ./demo/utils/test/utils_spec
-      working-directory: dogm/build
+      run: ctest
+      working-directory: dogm/build/demo


### PR DESCRIPTION
Finds unit tests automatically; doesn't require us to call binaries one by one. Going one directory deeper into the build directory to avoid running CUDA through ctest.