### PR TITLE
Introduce clang-tidy config, fix issues in timer

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,15 @@
+FormatStyle: file
+
+Checks: '
+-*,
+bugprone*,
+cppcoreguidelines*
+google*,
+llvm*,
+misc*,
+modernize*,
+readability*,
+'
+
+WarningsAsErrors: '*'
+

--- a/dogm/demo/utils/include/timer.h
+++ b/dogm/demo/utils/include/timer.h
@@ -14,7 +14,7 @@ class Timer
 public:
     Timer(const std::string& name) : m_name{name} { tic(); }
     void tic();
-    void toc(const bool print_me = false);
+    void toc(const bool print_split = false);
     int getLastSplitMs() const;
     void printLastSplitMs() const;
     void printStatsMs() const;

--- a/dogm/demo/utils/timer.cpp
+++ b/dogm/demo/utils/timer.cpp
@@ -42,7 +42,7 @@ void Timer::printLastSplitMs() const
 void Timer::printStatsMs() const
 {
     std::cout << m_name << " stats (" << m_splits.size() << " splits):\n";
-    if (m_splits.size() > 0)
+    if (!m_splits.empty())
     {
         std::vector<unsigned int> splits_ms{};
         for (const auto& split : m_splits)


### PR DESCRIPTION
Starting work on #38: first run of clang-tidy on timer.cpp. Executed using 

```shell
clang-tidy dogm/demo/utils/timer.cpp -- -Idogm/demo/utils/include
```

Added many checks from [the list](https://clang.llvm.org/extra/clang-tidy/checks/list.html). Can be extended in future if needed. My next step would be to include this first passing clang-tidy check in CI.