### PR TITLE
Run clang-tidy in CI

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -30,5 +30,7 @@ jobs:
     - name: Test Utils
       run: ctest
       working-directory: dogm/build/demo
+    - name: Install clang-tidy
+      run: sudo apt install clang-tidy
     - name: Clang-Tidy
       run: find dogm/demo/utils -iname '*.cpp' | xargs clang-tidy -p dogm/build

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -31,4 +31,4 @@ jobs:
       run: ctest
       working-directory: dogm/build/demo
     - name: Clang-Tidy
-      run: find dogm/demo/utils -iname '*.cpp' | xargs clang-tidy -p build
+      run: find dogm/demo/utils -iname '*.cpp' | xargs clang-tidy -p dogm/build

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -2,9 +2,9 @@ name: Build and test on Ubuntu 18.04
 
 on:
   push:
-    branches: [ master, test-clang-tidy-in-ci ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, test-clang-tidy-in-ci ]
+    branches: [ master ]
 
 jobs:
   build-and-test-ubuntu:

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -2,9 +2,9 @@ name: Build and test on Ubuntu 18.04
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, test-clang-tidy-in-ci ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, test-clang-tidy-in-ci ]
 
 jobs:
   build-and-test-ubuntu:
@@ -22,7 +22,7 @@ jobs:
     - name: Install CUDA toolkit
       run: sudo apt install nvidia-cuda-toolkit
     - name: Configure
-      run: mkdir build && cd build && cmake ..
+      run: mkdir build && cd build && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  ..
       working-directory: dogm
     - name: Build
       run: cmake --build build
@@ -30,3 +30,5 @@ jobs:
     - name: Test Utils
       run: ctest
       working-directory: dogm/build/demo
+    - name: Clang-Tidy
+      run: find dogm/demo/utils -iname '*.cpp' | xargs clang-tidy -p build

--- a/dogm/demo/utils/image_creation.cpp
+++ b/dogm/demo/utils/image_creation.cpp
@@ -102,7 +102,7 @@ cv::Mat compute_raw_measurement_grid_image(const dogm::DOGM& grid_map)
         {
             int index = y * grid_map.getGridSize() + x;
             const dogm::MeasurementCell& cell = meas_cells[index];
-            auto red = static_cast<int>(cell.occ_mass * 255.0f);
+            int red = static_cast<int>(cell.occ_mass * 255.0f);
             auto green = static_cast<int>(cell.free_mass * 255.0f);
             int blue = 255 - red - green;
 

--- a/dogm/demo/utils/image_creation.cpp
+++ b/dogm/demo/utils/image_creation.cpp
@@ -102,7 +102,7 @@ cv::Mat compute_raw_measurement_grid_image(const dogm::DOGM& grid_map)
         {
             int index = y * grid_map.getGridSize() + x;
             const dogm::MeasurementCell& cell = meas_cells[index];
-            int red = static_cast<int>(cell.occ_mass * 255.0f);
+            auto red = static_cast<int>(cell.occ_mass * 255.0f);
             auto green = static_cast<int>(cell.free_mass * 255.0f);
             int blue = 255 - red - green;
 


### PR DESCRIPTION
Partially addressing #38: I verified that CI fails on clang-tidy issues: https://github.com/cbachhuber/dynamic-occupancy-grid-map/runs/839214671.

Currently, only demo utils are checked. We can extend the list of checked files in future.