### PR TITLE
clang-tidy on cuda files 

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -32,5 +32,7 @@ jobs:
       working-directory: dogm/build/demo
     - name: Install clang-tidy
       run: sudo apt install clang-tidy
-    - name: Clang-Tidy
+    - name: Clang-Tidy on cpp
       run: find dogm/demo -iname '*.cpp' | xargs clang-tidy -p dogm/build
+    - name: Clang-Tidy on cuda (non-failing)
+      run: find dogm/src -iname '*.cu' | xargs -I{} clang-tidy -p build {} -- --cuda-host-only -Idogm/include | grep -v "clang-diagnostic-error"

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -33,6 +33,6 @@ jobs:
     - name: Install clang-tidy
       run: sudo apt install clang-tidy
     - name: Clang-Tidy on cpp
-      run: find dogm/demo -iname '*.cpp' | xargs clang-tidy -p dogm/build
+      run: find -iname '*.cpp' | xargs clang-tidy -p dogm/build
     - name: Clang-Tidy on cuda (non-failing)
       run: find dogm/src -iname '*.cu' | xargs -I{} clang-tidy -p build {} -- --cuda-host-only -Idogm/include | grep -v "clang-diagnostic-error"

--- a/dogm/src/.clang-tidy
+++ b/dogm/src/.clang-tidy
@@ -1,0 +1,16 @@
+FormatStyle: file
+
+Checks: '
+-*,
+bugprone*,
+cppcoreguidelines*
+google*,
+llvm*,
+misc*,
+modernize*,
+readability*,
+-clang-diagonstic-error
+'
+
+WarningsAsErrors: '-*'
+

--- a/dogm/src/.clang-tidy
+++ b/dogm/src/.clang-tidy
@@ -9,7 +9,6 @@ llvm*,
 misc*,
 modernize*,
 readability*,
--clang-diagonstic-error
 '
 
 WarningsAsErrors: '-*'

--- a/local_pipeline_ubuntu.sh
+++ b/local_pipeline_ubuntu.sh
@@ -40,7 +40,7 @@ make -j $(nproc)
 
 # TODO: extend to check more/all .cpp (and .cu) files
 cd ..
-find dogm/demo -iname '*.cpp' | xargs clang-tidy -p build
+find -iname '*.cpp' | xargs clang-tidy -p build
 
 ctest . -j $(nproc)
 ./demo/demo

--- a/local_pipeline_ubuntu.sh
+++ b/local_pipeline_ubuntu.sh
@@ -40,7 +40,7 @@ make -j $(nproc)
 
 # TODO: extend to check more/all .cpp (and .cu) files
 cd ..
-find dogm/demo/utils -iname '*.cpp' | xargs clang-tidy -p build
+find dogm/demo -iname '*.cpp' | xargs clang-tidy -p build
 
 ctest . -j $(nproc)
 ./demo/demo


### PR DESCRIPTION
Currenty, this is a backup solution: run clang-tidy on cuda files, but do not treat warnings as errors. This way, clang-tidy issues (including current compilation errors) will be reported in CI, but CI will not fail upon them.

I want to try to get a proper solution working, [people have done this before](https://github.com/dmlc/xgboost/pull/4034/files). I expect that we need to adjust something in the CMakeLists.txt. I'll try to set up a clean 'hello world' cuda project and run clang-tidy on that.

Btw: you might want to install https://github.com/apps/wip in this repository ;)