### PR TITLE
Replace raw pointers by std::vector for grid cell getters

### DIFF
--- a/dogm/demo/utils/image_creation.cpp
+++ b/dogm/demo/utils/image_creation.cpp
@@ -24,7 +24,7 @@ static float pignistic_transformation(float free_mass, float occ_mass)
 std::vector<Point<dogm::GridCell>> computeCellsWithVelocity(const dogm::DOGM& grid_map, float min_occupancy_threshold,
                                                             float min_velocity_threshold)
 {
-    dogm::GridCell* grid_cells = grid_map.getGridCells();
+    const auto grid_cells = grid_map.getGridCells();
     std::vector<Point<dogm::GridCell>> cells_with_velocity;
     for (int y = 0; y < grid_map.getGridSize(); y++)
     {
@@ -61,8 +61,6 @@ std::vector<Point<dogm::GridCell>> computeCellsWithVelocity(const dogm::DOGM& gr
             }
         }
     }
-
-    free(grid_cells);
 
     return cells_with_velocity;
 }
@@ -113,7 +111,7 @@ cv::Mat compute_raw_measurement_grid_image(const dogm::DOGM& grid_map)
 
 cv::Mat compute_dogm_image(const dogm::DOGM& grid_map, const std::vector<Point<dogm::GridCell>>& cells_with_velocity)
 {
-    dogm::GridCell* grid_cells = grid_map.getGridCells();
+    const auto grid_cells = grid_map.getGridCells();
     cv::Mat grid_img(grid_map.getGridSize(), grid_map.getGridSize(), CV_8UC3);
     for (int y = 0; y < grid_map.getGridSize(); y++)
     {
@@ -146,8 +144,6 @@ cv::Mat compute_dogm_image(const dogm::DOGM& grid_map, const std::vector<Point<d
     }
 
     addColorWheelToBottomRightCorner(grid_img);
-
-    free(grid_cells);
 
     return grid_img;
 }

--- a/dogm/demo/utils/image_creation.cpp
+++ b/dogm/demo/utils/image_creation.cpp
@@ -69,7 +69,7 @@ std::vector<Point<dogm::GridCell>> computeCellsWithVelocity(const dogm::DOGM& gr
 
 cv::Mat compute_measurement_grid_image(const dogm::DOGM& grid_map)
 {
-    dogm::MeasurementCell* meas_cells = grid_map.getMeasurementCells();
+    const auto meas_cells = grid_map.getMeasurementCells();
     cv::Mat grid_img(grid_map.getGridSize(), grid_map.getGridSize(), CV_8UC3);
     for (int y = 0; y < grid_map.getGridSize(); y++)
     {
@@ -86,14 +86,12 @@ cv::Mat compute_measurement_grid_image(const dogm::DOGM& grid_map)
         }
     }
 
-    free(meas_cells);
-
     return grid_img;
 }
 
 cv::Mat compute_raw_measurement_grid_image(const dogm::DOGM& grid_map)
 {
-    dogm::MeasurementCell* meas_cells = grid_map.getMeasurementCells();
+    const auto meas_cells = grid_map.getMeasurementCells();
     cv::Mat grid_img(grid_map.getGridSize(), grid_map.getGridSize(), CV_8UC3);
     for (int y = 0; y < grid_map.getGridSize(); y++)
     {
@@ -109,8 +107,6 @@ cv::Mat compute_raw_measurement_grid_image(const dogm::DOGM& grid_map)
             row_ptr[x] = cv::Vec3b(blue, green, red);
         }
     }
-
-    free(meas_cells);
 
     return grid_img;
 }

--- a/dogm/include/dogm/dogm.h
+++ b/dogm/include/dogm/dogm.h
@@ -41,7 +41,7 @@ public:
     void addMeasurementGrid(MeasurementCell* measurement_grid, bool device);
     void updateGrid(float dt);
 
-    GridCell* getGridCells() const;
+    std::vector<GridCell> getGridCells() const;
     std::vector<MeasurementCell> getMeasurementCells() const;
 
     ParticlesSoA getParticles() const;

--- a/dogm/include/dogm/dogm.h
+++ b/dogm/include/dogm/dogm.h
@@ -42,7 +42,7 @@ public:
     void updateGrid(float dt);
 
     GridCell* getGridCells() const;
-    MeasurementCell* getMeasurementCells() const;
+    std::vector<MeasurementCell> getMeasurementCells() const;
 
     ParticlesSoA getParticles() const;
 

--- a/dogm/src/dogm.cu
+++ b/dogm/src/dogm.cu
@@ -132,18 +132,19 @@ void DOGM::updateGrid(float dt)
     iteration++;
 }
 
-GridCell* DOGM::getGridCells() const
+std::vector<GridCell> DOGM::getGridCells() const
 {
-    auto grid_cells = (GridCell*)malloc(grid_cell_count * sizeof(GridCell));
+    std::vector<GridCell> grid_cells(static_cast<std::vector<GridCell>::size_type>(grid_cell_count));
 
-    CHECK_ERROR(cudaMemcpy(grid_cells, grid_cell_array, grid_cell_count * sizeof(GridCell), cudaMemcpyDeviceToHost));
+    CHECK_ERROR(
+        cudaMemcpy(grid_cells.data(), grid_cell_array, grid_cell_count * sizeof(GridCell), cudaMemcpyDeviceToHost));
 
     return grid_cells;
 }
 
 std::vector<MeasurementCell> DOGM::getMeasurementCells() const
 {
-    std::vector<MeasurementCell> meas_cells(grid_cell_count, MeasurementCell{});
+    std::vector<MeasurementCell> meas_cells(static_cast<std::vector<GridCell>::size_type>(grid_cell_count));
 
     CHECK_ERROR(cudaMemcpy(meas_cells.data(), meas_cell_array, grid_cell_count * sizeof(MeasurementCell),
                            cudaMemcpyDeviceToHost));

--- a/dogm/src/dogm.cu
+++ b/dogm/src/dogm.cu
@@ -141,12 +141,12 @@ GridCell* DOGM::getGridCells() const
     return grid_cells;
 }
 
-MeasurementCell* DOGM::getMeasurementCells() const
+std::vector<MeasurementCell> DOGM::getMeasurementCells() const
 {
-    auto meas_cells = (MeasurementCell*)malloc(grid_cell_count * sizeof(MeasurementCell));
+    std::vector<MeasurementCell> meas_cells(grid_cell_count, MeasurementCell{});
 
-    CHECK_ERROR(
-        cudaMemcpy(meas_cells, meas_cell_array, grid_cell_count * sizeof(MeasurementCell), cudaMemcpyDeviceToHost));
+    CHECK_ERROR(cudaMemcpy(meas_cells.data(), meas_cell_array, grid_cell_count * sizeof(MeasurementCell),
+                           cudaMemcpyDeviceToHost));
 
     return meas_cells;
 }


### PR DESCRIPTION
Use `std::vector` instead of raw pointers to array
- Vector elements are also stored on the heap, no difference to existing implementation
- Vector is moved, not copied when returning from `getGridCells` and `getMeasurementCells` thanks to copy elision. Negligible overhead compared to returning a raw pointer
- Provides all the convenience, expressiveness, and safety of `std::vector`
- No more need to do manual memory allocation and deallocation

I currently have no CUDA device available, hence I cannot execute the CUDA related tests. Could you please verify that the demo still works on your PC, @TheCodez?