### PR TITLE
Use smart pointers in renderer

### DIFF
--- a/dogm/demo/simulator/include/mapping/opengl/renderer.h
+++ b/dogm/demo/simulator/include/mapping/opengl/renderer.h
@@ -23,10 +23,7 @@ public:
 
     void renderToTexture(Texture& polar_texture);
 
-    Framebuffer* getFrameBuffer() const { return framebuffer; }
-
-private:
-    void generateCircleSegmentVertices(std::vector<Vertex>& vertices, float fov, float radius, float cx, float cy);
+    std::shared_ptr<Framebuffer> getFrameBuffer() const { return framebuffer; }
 
 private:
     int grid_size;

--- a/dogm/demo/simulator/include/mapping/opengl/renderer.h
+++ b/dogm/demo/simulator/include/mapping/opengl/renderer.h
@@ -13,6 +13,7 @@
 #include "shader.h"
 #include "texture.h"
 
+#include <memory>
 #include <vector>
 
 class Renderer
@@ -28,9 +29,9 @@ public:
 private:
     int grid_size;
 
-    Polygon* polygon;
-    Shader* shader;
-    Framebuffer* framebuffer;
+    std::unique_ptr<Polygon> polygon;
+    std::unique_ptr<Shader> shader;
+    std::shared_ptr<Framebuffer> framebuffer;
 
-    GLFWwindow* window;
+    std::unique_ptr<GLFWwindow, decltype(&glfwDestroyWindow)> window{nullptr, glfwDestroyWindow};
 };

--- a/dogm/demo/simulator/mapping/laser_to_meas_grid.cu
+++ b/dogm/demo/simulator/mapping/laser_to_meas_grid.cu
@@ -53,7 +53,7 @@ dogm::MeasurementCell* LaserMeasurementGrid::generateGrid(const std::vector<floa
     // render cartesian image to texture using polar texture
     renderer->renderToTexture(polar_texture);
 
-    Framebuffer* framebuffer = renderer->getFrameBuffer();
+    auto framebuffer = renderer->getFrameBuffer();
     cudaSurfaceObject_t cartesian_surface;
 
     framebuffer->beginCudaAccess(&cartesian_surface);

--- a/dogm/demo/simulator/mapping/opengl/renderer.cpp
+++ b/dogm/demo/simulator/mapping/opengl/renderer.cpp
@@ -40,8 +40,8 @@ Renderer::Renderer(int grid_size, float fov, float grid_range, float max_range) 
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
     glfwWindowHint(GLFW_VISIBLE, GL_FALSE);
 
-    window = glfwCreateWindow(grid_size, grid_size, "GPU Occupancy Grid Map", nullptr, nullptr);
-    glfwMakeContextCurrent(window);
+    window.reset(glfwCreateWindow(grid_size, grid_size, "GPU Occupancy Grid Map", nullptr, nullptr));
+    glfwMakeContextCurrent(window.get());
 
     glewExperimental = GL_TRUE;
     glewInit();
@@ -53,17 +53,13 @@ Renderer::Renderer(int grid_size, float fov, float grid_range, float max_range) 
     // generateCircleSegmentVertices(vertices, fov, range, 0.0f, 0.0f);
     generateCircleSegmentVertices(vertices, fov, range, 0.0f, -1.0f);
 
-    polygon = new Polygon(vertices.data(), vertices.size());
-    shader = new Shader();
-    framebuffer = new Framebuffer(grid_size, grid_size);
+    polygon = std::make_unique<Polygon>(vertices.data(), vertices.size());
+    shader = std::make_unique<Shader>();
+    framebuffer = std::make_shared<Framebuffer>(grid_size, grid_size);
 }
 
 Renderer::~Renderer()
 {
-    delete polygon;
-    delete shader;
-    delete framebuffer;
-
     glfwTerminate();
 }
 

--- a/dogm/demo/simulator/mapping/opengl/renderer.cpp
+++ b/dogm/demo/simulator/mapping/opengl/renderer.cpp
@@ -6,6 +6,31 @@
 
 #include <cmath>
 
+namespace
+{
+void generateCircleSegmentVertices(std::vector<Vertex>& vertices, float fov, float radius, float cx, float cy)
+{
+    vertices.emplace_back(Vertex(glm::vec2(cx, cy), glm::vec2(0.0f, 0.0f)));
+
+    float halfFov = fov / 2;
+    float startAngle = 90 - halfFov;
+    float endAngle = 90 + halfFov;
+
+    for (int angle = startAngle; angle <= endAngle; angle++)
+    {
+        float angle_radians = angle * M_PI / 180.0f;
+
+        float x_val = cos(angle_radians);
+        float y_val = sin(angle_radians);
+
+        float x = radius * x_val;
+        float y = radius * y_val;
+
+        vertices.emplace_back(Vertex(glm::vec2(cx + x, cy + y), glm::vec2((angle - startAngle) / fov, 1.0f)));
+    }
+}
+}  // namespace
+
 Renderer::Renderer(int grid_size, float fov, float grid_range, float max_range) : grid_size(grid_size)
 {
     glfwInit();
@@ -60,26 +85,4 @@ void Renderer::renderToTexture(Texture& polar_texture)
     polygon->draw();
 
     framebuffer->unbind();
-}
-
-void Renderer::generateCircleSegmentVertices(std::vector<Vertex>& vertices, float fov, float radius, float cx, float cy)
-{
-    vertices.emplace_back(Vertex(glm::vec2(cx, cy), glm::vec2(0.0f, 0.0f)));
-
-    float halfFov = fov / 2;
-    float startAngle = 90 - halfFov;
-    float endAngle = 90 + halfFov;
-
-    for (int angle = startAngle; angle <= endAngle; angle++)
-    {
-        float angle_radians = angle * M_PI / 180.0f;
-
-        float x_val = cos(angle_radians);
-        float y_val = sin(angle_radians);
-
-        float x = radius * x_val;
-        float y = radius * y_val;
-
-        vertices.emplace_back(Vertex(glm::vec2(cx + x, cy + y), glm::vec2((angle - startAngle) / fov, 1.0f)));
-    }
 }


### PR DESCRIPTION
On the way, I freed `generateCircleSegmentVertices`. I don't see the need to make this a member function.