### PR TITLE
Use perfect forwarding in lambda

### DIFF
--- a/dogm/demo/main.cpp
+++ b/dogm/demo/main.cpp
@@ -82,9 +82,8 @@ int main(int argc, const char** argv)
     {
         dogm::MeasurementCell* meas_grid = grid_generator.generateGrid(sim_data[step].measurements);
 
-        const auto update_grid_caller = [&grid_map](dogm::MeasurementCell* meas, const float pose_x, const float pose_y,
-                                                    const float yaw, const float dt, const bool device) {
-            grid_map.updateGrid(meas, pose_x, pose_y, yaw, dt, device);
+        const auto update_grid_caller = [&grid_map](auto&&... args) {
+            grid_map.updateGrid(std::forward<decltype(args)>(args)...);
         };
 
         cycle_timer.timeFunctionCall(true, update_grid_caller, meas_grid, sim_data[step].ego_pose.x,


### PR DESCRIPTION
I saw #80 too late to review, so here comes my suggestion: if you're just forwarding arguments, express that in code :wink:

I'm currently not on a machine on which I can run this, so I haven't tested that. I only know that it builds.