### PR TITLE
Add clang installation

### DIFF
--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -31,8 +31,8 @@ jobs:
       run: ctest
       working-directory: dogm/build/demo
     - name: Install clang-tidy
-      run: sudo apt install clang-tidy
+      run: sudo apt install clang clang-tidy
     - name: Clang-Tidy on cpp (non-failing)
-      run: find -iname '*.cpp' | xargs -I{} clang-tidy -p dogm/build {} | grep -v "clang-diagnostic-error"
+      run: find -iname '*.cpp' | xargs -I{} clang-tidy -p dogm/build {}
     - name: Clang-Tidy on cuda (non-failing)
       run: find dogm/src -iname '*.cu' | xargs -I{} clang-tidy -p build {} -- --cuda-host-only -Idogm/include | grep -v "clang-diagnostic-error"

--- a/.github/workflows/ubuntu_build.yml
+++ b/.github/workflows/ubuntu_build.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Clang-Tidy on cpp (non-failing)
       run: find -iname '*.cpp' | xargs -I{} clang-tidy -p dogm/build {}
     - name: Clang-Tidy on cuda (non-failing)
-      run: find dogm/src -iname '*.cu' | xargs -I{} clang-tidy -p build {} -- --cuda-host-only -Idogm/include | grep -v "clang-diagnostic-error"
+      run: find dogm/src -iname '*.cu' | xargs -I{} clang-tidy -p build {} -- --cuda-host-only -Idogm/include


### PR DESCRIPTION
Resolves #92: Status quo is that we get

```
/usr/include/time.h:29:10: error: 'stddef.h' file not found [clang-diagnostic-error]
#include <stddef.h>
         ^
```

in our clang-tidy runs. https://stackoverflow.com/a/52728225/7260972 says we should install `clang`, and that indeed fixes clang-tidy diagnostics in my Ubuntu 18.04 container. Let's see if this also works in CI.

Why are we grepping `clang-diagnostic-error` away? We're particularly interested in those, as they tell us where analysis is not failing.